### PR TITLE
Small makefile punctilious modification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,11 @@
-.DEFAULT: all
-
-CHART=java
-RELEASE=chart-${CHART}-release
-NAMESPACE=chart-tests
-TEST=${RELEASE}-test-service
-ACR=hmctssandbox
-AKS_RESOURCE_GROUP=cnp-aks-sandbox-rg
-AKS_CLUSTER= cnp-aks-sandbox-cluster
+.DEFAULT_GOAL := all
+CHART := java
+RELEASE := chart-${CHART}-release
+NAMESPACE := chart-tests
+TEST := ${RELEASE}-test-service
+ACR := hmctssandbox
+AKS_RESOURCE_GROUP := cnp-aks-sandbox-rg
+AKS_CLUSTER := cnp-aks-sandbox-cluster
 
 setup:
 	az configure --defaults acr=${ACR}
@@ -27,3 +26,5 @@ test:
 	helm test ${RELEASE}
 
 all: setup clean lint deploy test
+
+.PHONY: setup clean lint deploy test all

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # chart-java
+
 This chart is intended for simple Java microservices.
 
 We will take small PRs and small features to this chart but more complicated needs should be handled in your own chart.
 
 ## Example configuration
+
 ```
 applicationPort: 8080
 environment:
@@ -20,38 +22,41 @@ configmap:
 
 The following table lists the configurable parameters of the Java chart and their default values.
 
-| Parameter          | Description                                               | Default                     |
-|--------------------|-----------------------------------------------------------|-----------------------------|
-| `applicationPort`  | The port your app runs on in its container                | `4550`                      |
-| `image`            | Full image url                                            | `hmctssandbox.azurecr.io/hmcts/spring-boot-template` (but overridden by pipeline) |
-| `environment`      | A map containing all environment values you wish to set   | `nil`                       |
-| `configmap`        | A config map, can be used for environment specific config | `nil`                       |
-| `memoryRequests`   | Requests for memory                                       | `512Mi`                     |
-| `cpuRequests`      | Requests for cpu                                          | `100m`                      |
-| `memoryLimits`     | Memory limits                                             | `1024Mi`                    |
-| `cpuLimits`        | CPU limits                                                | `2500m`                     |
-| `ingressHost`      | Host for ingress controller to map the container to       | `chart-java.service.core-compute-saat.internal` (but overridden by pipeline) |
-| `readinessPath`    | Path of HTTP readiness probe                              | `/health`                   |
-| `readinessDelay`   | Readiness probe inital delay (seconds)                    | `30`                        |
-| `readinessTimeout` | Readiness probe timeout (seconds)                         | `3`                         |
-| `readinessPeriod`  | Readiness probe period (seconds)                          | `15`                        |
-| `livenessPath`     | Path of HTTP liveness probe                               | `/health`                   |
-| `livenessDelay`    | Liveness probe inital delay (seconds)                     | `30`                        |
-| `livenessTimeout`  | Liveness probe timeout (seconds)                          | `3`                         |
-| `livenessPeriod`   | Liveness probe period (seconds)                           | `15`                        |
-| `livenessFailureThreshold`| Liveness failure threshold                         | `3`                         |
+| Parameter                  | Description                                               | Default                                                                           |
+| -------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `applicationPort`          | The port your app runs on in its container                | `4550`                                                                            |
+| `image`                    | Full image url                                            | `hmctssandbox.azurecr.io/hmcts/spring-boot-template` (but overridden by pipeline) |
+| `environment`              | A map containing all environment values you wish to set   | `nil`                                                                             |
+| `configmap`                | A config map, can be used for environment specific config | `nil`                                                                             |
+| `memoryRequests`           | Requests for memory                                       | `512Mi`                                                                           |
+| `cpuRequests`              | Requests for cpu                                          | `100m`                                                                            |
+| `memoryLimits`             | Memory limits                                             | `1024Mi`                                                                          |
+| `cpuLimits`                | CPU limits                                                | `2500m`                                                                           |
+| `ingressHost`              | Host for ingress controller to map the container to       | `chart-java.service.core-compute-saat.internal` (but overridden by pipeline)      |
+| `readinessPath`            | Path of HTTP readiness probe                              | `/health`                                                                         |
+| `readinessDelay`           | Readiness probe inital delay (seconds)                    | `30`                                                                              |
+| `readinessTimeout`         | Readiness probe timeout (seconds)                         | `3`                                                                               |
+| `readinessPeriod`          | Readiness probe period (seconds)                          | `15`                                                                              |
+| `livenessPath`             | Path of HTTP liveness probe                               | `/health`                                                                         |
+| `livenessDelay`            | Liveness probe inital delay (seconds)                     | `30`                                                                              |
+| `livenessTimeout`          | Liveness probe timeout (seconds)                          | `3`                                                                               |
+| `livenessPeriod`           | Liveness probe period (seconds)                           | `15`                                                                              |
+| `livenessFailureThreshold` | Liveness failure threshold                                | `3`                                                                               |
 
 ## Development and Testing
-Default configuration (e.g. default image and ingress host) is setup for sandbox.  This is suitable for local development and testing.
-* Ensure you have logged in with `az cli` and are using `sandbox` subscription.
-* For local development see the `Makefile` for available targets.
-* To execute an end-to-end build, deploy and test run `make all`.
-* to clean up deployed releases, charts, test pods and local charts, run `make clean`
 
-`helm test` will deploy a busybox container alongside the release which performs a simple HTTP request against the service health endpoint.  If it doesn't return `HTTP 200` the test will fail.  __NOTE:__ it does NOT run with `--cleanup` so the test pod will be available for inspection.
+Default configuration (e.g. default image and ingress host) is setup for sandbox. This is suitable for local development and testing.
+
+- Ensure you have logged in with `az cli` and are using `sandbox` subscription (use `az account show` to display the current one).
+- For local development see the `Makefile` for available targets.
+- To execute an end-to-end build, deploy and test run `make`.
+- to clean up deployed releases, charts, test pods and local charts, run `make clean`
+
+`helm test` will deploy a busybox container alongside the release which performs a simple HTTP request against the service health endpoint. If it doesn't return `HTTP 200` the test will fail. **NOTE:** it does NOT run with `--cleanup` so the test pod will be available for inspection.
 
 ## Azure DevOps Builds
-Builds are run against the 'nonprod' AKS cluster.
-* `azure-pipelines.yaml`: triggered when pull requests are created.  This build will run `helm lint`, deploy the chart using `ci-values.yaml` and run `helm test`.
-* `release.yaml`: triggered when the repository is tagged (e.g. when a release is created).  Also performs linting and testing, and will publish the chart to ACR on success.
 
+Builds are run against the 'nonprod' AKS cluster.
+
+- `azure-pipelines.yaml`: triggered when pull requests are created. This build will run `helm lint`, deploy the chart using `ci-values.yaml` and run `helm test`.
+- `release.yaml`: triggered when the repository is tagged (e.g. when a release is created). Also performs linting and testing, and will publish the chart to ACR on success.


### PR DESCRIPTION
Woops, sorry my linter changed the spacing in the readme, but the content is mainly the same.

- Add default goal and phony targets
- Add the command example to verify the current subscription in doc