### PR TITLE
Remove empty values that cause warning

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 0.0.4
+version: 0.0.5
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords: 
 - java

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -1,7 +1,5 @@
 applicationPort: 4550
 image: hmctssandbox.azurecr.io/hmcts/spring-boot-template
-environment:
-configmap:
 memoryRequests: "512Mi"
 cpuRequests: "100m"
 memoryLimits: "1024Mi"


### PR DESCRIPTION
While using this chart as a requirement I get:

2018/11/28 11:15:55 warning: skipped value for configmap: Not a table.
2018/11/28 11:15:55 warning: skipped value for configmap: Not a table.
2018/11/28 11:15:55 warning: skipped value for configmap: Not a table.
2018/11/28 11:15:55 warning: skipped value for configmap: Not a table.

When using the following Values.yaml file:

...
  configmap:
    POSTGRES_HOST: localhost
    POSTGRES_SSL_MODE: disable
...