### PR TITLE
RPE-867:  moved the secret environment definitions first

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 0.0.7
+version: 0.0.8
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/_helpers.tpl
+++ b/java/templates/_helpers.tpl
@@ -5,10 +5,10 @@ The key or "environment variable" must be uppercase and contain only numbers or 
 {{- define "java.environment" -}}
   {{- if . -}}
     {{- range $key, $val := . }}
-- name: {{ if $key | regexMatch "^[A-Z_0-9]+$" -}}
+- name: {{ if $key | regexMatch "^[^.-]+$" -}}
           {{- $key }}
         {{- else -}}
-            {{- fail (join "Environment variables have to upper case  and match \"[A-Z_0-9]+\" given: " ($key|quote)) -}}
+            {{- fail (join "Environment variables can not contain '.' or '-' Failed key: " ($key|quote)) -}}
         {{- end }}
   value: {{ $val | quote }}
     {{- end }}
@@ -29,14 +29,14 @@ Example format:
   {{- if . -}}
     {{- range $key, $val := . }}
       {{- if $val }}
-- name: {{ if $key | regexMatch "^[A-Z_0-9]+$" -}}
+- name: {{ if $key | regexMatch "^[^.-]+$" -}}
           {{- $key }}
         {{- else -}}
-            {{- fail (join "Environment variables have be uppercase and match \"[A-Z_0-9]+\". Failed key: " ($key|quote)) -}}
+            {{- fail (join "Environment variables can not contain '.' or '-' Failed key: " ($key|quote)) -}}
         {{- end }}
   valueFrom:
     secretKeyRef:
-      name: {{ required "Each item in \"secrets:\" needs a secretRef member" $val.secretRef   }}
+      name: {{ required "Each item in \"secrets:\" needs a secretRef member" $val.secretRef }}
       key: {{ required "Each item in \"secrets:\" needs a key member" $val.key }}
       {{- end }}
     {{- end }}

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -15,7 +15,14 @@ spec:
       app.kubernetes.io/name: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        {{- if .Values.buildID }}
+        buildID: {{ .Values.buildID }}
+        {{- end }}
       labels:
+        {{- if .Values.draft }}
+        draft: {{ .Values.draft }}
+        {{- end }}
         app.kubernetes.io/name: {{ .Release.Name }}
     spec:
       containers:
@@ -24,8 +31,8 @@ spec:
 
         {{- if or .Values.environment .Values.secrets }}
         env:
-          {{- (include "java.environment" .Values.environment) | indent 8 }}
           {{- (include "java.secrets" .Values.secrets) | indent 8 }}
+          {{- (include "java.environment" .Values.environment) | indent 8 }}
         {{- end -}}
 
         {{- if .Values.configmap }}


### PR DESCRIPTION
- moved the secret environment definitions before the others so that the other environment variables can use them in their substitution definitions.
- relaxed the uppercase and punctuation restrictions on environment variables 