### PR TITLE
Suggested changes from working with CMC helm integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,12 @@ RELEASE := chart-${CHART}-release
 NAMESPACE := chart-tests
 TEST := ${RELEASE}-test-service
 ACR := hmctssandbox
+ACR_SUBSCRIPTION := DCD-CFT-Sandbox
 AKS_RESOURCE_GROUP := cnp-aks-sandbox-rg
 AKS_CLUSTER := cnp-aks-sandbox-cluster
 
 setup:
+	az account set --subscription ${ACR_SUBSCRIPTION}
 	az configure --defaults acr=${ACR}
 	az acr helm repo add
 	az aks get-credentials --resource-group ${AKS_RESOURCE_GROUP} --name ${AKS_CLUSTER}

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the Java chart and thei
 | `cpuRequests`              | Requests for cpu | `100m`|
 | `memoryLimits`             | Memory limits| `1024Mi`|
 | `cpuLimits`                | CPU limits | `2500m`|
-| `ingressHost`              | Host for ingress controller to map the container to | `chart-java.service.core-compute-saat.internal`<br>(but overridden by pipeline)|
+| `ingressHost`              | Host for ingress controller to map the container to | `nil`|
 | `readinessPath`            | Path of HTTP readiness probe | `/health`|
 | `readinessDelay`           | Readiness probe inital delay (seconds)| `30`|
 | `readinessTimeout`         | Readiness probe timeout (seconds)| `3`|

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 0.0.9
+version: 0.0.10
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/_helpers.tpl
+++ b/java/templates/_helpers.tpl
@@ -42,3 +42,16 @@ Example format:
     {{- end }}
   {{- end -}}
 {{- end }}
+
+{{/*
+ref: https://github.com/helm/charts/blob/master/stable/postgresql/templates/_helpers.tpl
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "hmcts.releaseName" -}}
+{{- if .Values.releaseNameOverride -}}
+{{- .Values.releaseNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}

--- a/java/templates/_helpers.tpl
+++ b/java/templates/_helpers.tpl
@@ -50,8 +50,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "hmcts.releaseName" -}}
 {{- if .Values.releaseNameOverride -}}
-{{- .Values.releaseNameOverride | trunc 63 | trimSuffix "-" -}}
+{{- .Values.releaseNameOverride | trunc 53 | trimSuffix "-" -}}
 {{- else -}}
-{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 53 | trimSuffix "-" -}}
 {{- end -}}
 {{- end -}}

--- a/java/templates/configmap.yaml
+++ b/java/templates/configmap.yaml
@@ -5,10 +5,10 @@ kind: ConfigMap
 metadata:
   name: {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/instance: {{ template "hmcts.releaseName" . }}
 data:
   {{- range $key, $val := .Values.configmap }}
   {{ $key }}: {{ $val | quote }}

--- a/java/templates/configmap.yaml
+++ b/java/templates/configmap.yaml
@@ -1,14 +1,16 @@
+{{- if .Values.configmap }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
 data:
   {{- range $key, $val := .Values.configmap }}
   {{ $key }}: {{ $val | quote }}
   {{- end}}
+{{- end}}

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -2,32 +2,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}
+  name:  {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name: {{ .Release.Name }}
+      app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
   template:
     metadata:
-      annotations:
-        {{- if .Values.buildID }}
-        buildID: {{ .Values.buildID }}
-        {{- end }}
       labels:
         {{- if .Values.draft }}
         draft: {{ .Values.draft }}
         {{- end }}
-        app.kubernetes.io/name: {{ .Release.Name }}
+        app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
     spec:
       containers:
       - image: {{ .Values.image }}
-        name: {{ .Release.Name }}
+        name:  {{ template "hmcts.releaseName" . }}
 
         {{- if or .Values.environment .Values.secrets }}
         env:

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -4,15 +4,15 @@ kind: Deployment
 metadata:
   name:  {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/instance: {{ template "hmcts.releaseName" . }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+      app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
   template:
     metadata:
       annotations:
@@ -23,11 +23,11 @@ spec:
         {{- if .Values.draft }}
         draft: {{ .Values.draft }}
         {{- end }}
-        app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+        app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
     spec:
       containers:
       - image: {{ .Values.image }}
-        name:  {{ template "hmcts.releaseName" . }}
+        name: {{ template "hmcts.releaseName" . }}
 
         {{- if or .Values.environment .Values.secrets }}
         env:
@@ -38,7 +38,7 @@ spec:
         {{- if .Values.configmap }}
         envFrom:
           - configMapRef:
-              name: {{ .Release.Name }}
+              name: {{ template "hmcts.releaseName" . }}
         {{- end }}
         resources:
           requests:

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
   template:
     metadata:
+      annotations:
+        {{- if .Values.buildID }}
+        buildID: {{ .Values.buildID }}
+        {{- end }}
       labels:
         {{- if .Values.draft }}
         draft: {{ .Values.draft }}

--- a/java/templates/ingress.yaml
+++ b/java/templates/ingress.yaml
@@ -3,12 +3,12 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name:  {{ template "hmcts.releaseName" . }}
+  name: {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/instance: {{ template "hmcts.releaseName" . }}
   annotations:
     kubernetes.io/ingress.class: traefik
 spec:
@@ -18,6 +18,6 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName:  {{ template "hmcts.releaseName" . }}
+          serviceName: {{ template "hmcts.releaseName" . }}
           servicePort: 80
 {{- end}}

--- a/java/templates/ingress.yaml
+++ b/java/templates/ingress.yaml
@@ -1,13 +1,14 @@
+{{- if .Values.ingressHost }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}
+  name:  {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
   annotations:
     kubernetes.io/ingress.class: traefik
 spec:
@@ -17,5 +18,6 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: {{ .Release.Name }}
+          serviceName:  {{ template "hmcts.releaseName" . }}
           servicePort: 80
+{{- end}}

--- a/java/templates/service.yaml
+++ b/java/templates/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name:  {{ template "hmcts.releaseName" . }}
+  name: {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/instance: {{ template "hmcts.releaseName" . }}
 spec:
   ports:
     - name: http
@@ -15,4 +15,4 @@ spec:
       port: 80
       targetPort: {{ .Values.applicationPort }}
   selector:
-    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
+    app.kubernetes.io/name: {{ template "hmcts.releaseName" . }}

--- a/java/templates/service.yaml
+++ b/java/templates/service.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Release.Name }}
+  name:  {{ template "hmcts.releaseName" . }}
   labels:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance:  {{ template "hmcts.releaseName" . }}
 spec:
   ports:
     - name: http
@@ -15,4 +15,4 @@ spec:
       port: 80
       targetPort: {{ .Values.applicationPort }}
   selector:
-    app.kubernetes.io/name: {{ .Release.Name }}
+    app.kubernetes.io/name:  {{ template "hmcts.releaseName" . }}

--- a/java/templates/tests/test-service.yaml
+++ b/java/templates/tests/test-service.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ .Release.Name }}-test-service"
+  name: {{ template "hmcts.releaseName" . }}-test
   annotations:
     "helm.sh/hook": test-success
 spec:
   containers:
-  - name: {{ .Release.Name }}-test-service
+  - name: {{ template "hmcts.releaseName" . }}-test
     image: busybox
     env:
       - name: SERVICE_NAME
-        value: {{ .Release.Name }}
+        value: {{ template "hmcts.releaseName" . }}
     command: ["sh", "-c", "httpstatuscode=$(wget -S http://$SERVICE_NAME/health 2>&1 | grep HTTP/ | awk 'END{print $2}') && [ \"$httpstatuscode\" = \"200\" ]"]
   restartPolicy: Never

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -4,7 +4,6 @@ memoryRequests: '512Mi'
 cpuRequests: '100m'
 memoryLimits: '1024Mi'
 cpuLimits: '2500m'
-ingressHost: chart-java.service.core-compute-saat.internal
 readinessPath: '/health'
 readinessDelay: 30
 readinessTimeout: 3


### PR DESCRIPTION
CMC require the feature-toggle-api (https://github.com/hmcts/feature-toggle-api) as part of the AKS stack - we can't rely on AAT for this.

Currently if I pull in the nodejs and java charts (https://github.com/hmcts/cmc-citizen-frontend/pull/1322) - we get many of the K8S resources named the same (deployment, configmap, etc) - so Helm does not deploy correctly (`Error: release cmc-citizen-frontend-pr-1322 failed: configmaps "cmc-citizen-frontend-pr-1322" already exists`).

I am planning on updating nodejs chart in the same way.

Change summary:

- No configmap or ingress unless defined in values (`configmap` and `ingressHost`)
- `ingressHost` removed from default values - this might be required (as in our citizen-frontend)
- `releaseName` - add override to allow multiple hmcts charts to be imported