### PR TITLE
CNP-1155_pod_sec - prevent pod from running container process as root

### DIFF
--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -9,6 +9,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/instance: {{ template "hmcts.releaseName" . }}
 spec:
+  securityContext:
+    runAsUser: 1000
+    fsGroup: 2000
   replicas: 1
   selector:
     matchLabels:
@@ -66,3 +69,5 @@ spec:
           timeoutSeconds: {{ .Values.readinessTimeout }}
           periodSeconds: {{ .Values.readinessPeriod }}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
This change will prevent pod from running container processes as root, please refer to the documentation for more details:
https://tools.hmcts.net/confluence/display/CNP/Pod+Security#PodSecurity-SecurityContext