### PR TITLE
Add dns support

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 0.0.12
+version: 0.0.13
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/ingress.yaml
+++ b/java/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingressHost }}
+{{ if or (.Values.ingressHost ) (.Values.registerAdditionalDns.enabled) }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -13,6 +13,7 @@ metadata:
     kubernetes.io/ingress.class: traefik
 spec:
   rules:
+  {{- if .Values.ingressHost }}
   - host: {{ .Values.ingressHost }}
     http:
       paths:
@@ -20,4 +21,14 @@ spec:
         backend:
           serviceName: {{ template "hmcts.releaseName" . }}
           servicePort: 80
+  {{- end }}
+  {{- if .Values.registerAdditionalDns.enabled }}
+  - host: {{ .Values.registerAdditionalDns.prefix }}-{{ .Values.registerAdditionalDns.primaryIngressHost }}
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: {{ template "hmcts.releaseName" . }}
+          servicePort: 80
+  {{- end }}
 {{- end}}

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -1,5 +1,7 @@
 applicationPort: 4550
 image: hmctssandbox.azurecr.io/hmcts/spring-boot-template
+registerAdditionalDns:
+  enabled: false
 memoryRequests: '512Mi'
 cpuRequests: '25m'
 memoryLimits: '1024Mi'


### PR DESCRIPTION
As per https://github.com/hmcts/chart-nodejs - adding support for additional dns when imported as an additional chart. As per: feature toggle api. This is broken right now: https://github.com/hmcts/feature-toggle-api/blob/3788aabd9edf3725f7e351a566122bf1a2a142ee/charts/rpe-feature-toggle-api/values.template.yaml#L1