### PR TITLE
Adding ability to disable key vaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,11 @@ keyVaults:
 - *<SECRET_NAME>* Secret name as it is in the vault. Note this is case and punctuation sensitive. i.e. in s2s there is the `microservicekey-cmcLegalFrontend` secret.
 - *excludeEnvironmentSuffix*: This is used for the global key vaults where there is not environment suffix ( e.g `-aat` ) required. It defaults to false if it is not there and should only be added if you are using a global key-vault.
 
-**Note**: to enable `keyVaults` to be mounted as flexvolumes, your service principal credentials need to be added to your namespace as a Kubernetes secret named `kvcreds` and accessible by the KeyVault FlexVolume driver. 
+**Note**: To enable `keyVaults` to be mounted as flexvolumes :
+
+- When not using Jenkins, explicitly set global.enableKeyVaults to `true` .
+- When not using pod identity, your service principal credentials need to be added to your namespace as a Kubernetes secret named `kvcreds` and accessible by the KeyVault FlexVolume driver. 
+
 
 ## Development and Testing
 

--- a/README.md
+++ b/README.md
@@ -157,7 +157,6 @@ keyVaults:
 - *excludeEnvironmentSuffix*: This is used for the global key vaults where there is not environment suffix ( e.g `-aat` ) required. It defaults to false if it is not there and should only be added if you are using a global key-vault.
 
 **Note**: To enable `keyVaults` to be mounted as flexvolumes :
-
 - When not using Jenkins, explicitly set global.enableKeyVaults to `true` .
 - When not using pod identity, your service principal credentials need to be added to your namespace as a Kubernetes secret named `kvcreds` and accessible by the KeyVault FlexVolume driver. 
 

--- a/ci-values.yaml
+++ b/ci-values.yaml
@@ -40,3 +40,4 @@ global:
   subscriptionId: "1c4f0704-a29e-403d-b719-b90c34ef14c9"
   tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
   environment: aat
+  enableKeyVaults: true

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 2.1.1
+version: 2.2.1
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 2.2.1
+version: 2.2.0
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -44,7 +44,7 @@ spec:
                 - {{ template "hmcts.releaseName" . }}
             topologyKey: "kubernetes.io/hostname"
       {{- end }}
-      {{- if .Values.keyVaults }}
+      {{- if and .Values.keyVaults .Values.global.enableKeyVaults }}
       volumes:
         {{- $globals := .Values.global }}
         {{- $aadIdentityName := .Values.aadIdentityName }}
@@ -86,7 +86,7 @@ spec:
               name: {{ template "hmcts.releaseName" . }}
         {{- end }}
 
-        {{- if .Values.keyVaults }}
+        {{- if and .Values.keyVaults .Values.global.enableKeyVaults }}
         volumeMounts:
           {{- range $key, $value := .Values.keyVaults }}
           - name: vault-{{ $key }}

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -35,3 +35,5 @@ postgresql:
   postgresqlUsername: javapostgres
   postgresqlPassword: javapassword
   postgresqlDatabase: javadatabase
+global:
+  enableKeyVaults: false


### PR DESCRIPTION
### Change description ###

Adding ability to disable key vaults. Setting it at global level as we want to disable keyvaults by default , so that the chart can run anywhere(local) without the need to disable anything.  global level will help Jenkins control it so that it doesn't become a breaking change when teams starts moving to latest chart. They would still need to enable it in flux for envs like AAT where they want to use keyvaults, but sounds still better as not many are using flux yet.

**Does this PR introduce a breaking change?** (check one with "x")

```
[x] Yes
[ ] No
```
