### PR TITLE
Bump postgres

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 2.1.1
+version: 2.1.2
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/requirements.yaml
+++ b/java/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
    - name: postgresql
-     version: ~4.0.0
+     version: ~5.0.0
      repository: '@stable'
      condition: postgresql.enabled

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -35,3 +35,6 @@ postgresql:
   postgresqlUsername: javapostgres
   postgresqlPassword: javapassword
   postgresqlDatabase: javadatabase
+  extraEnv:
+  - name: POSTGRESQL_DATABASE
+    value: javadatabase


### PR DESCRIPTION

### Change description ###

Postgres issues complaining about database not existing:

```
08:35:49.63 INFO  ==> ** Starting PostgreSQL **
2019-06-12 08:35:49.751 GMT [1] LOG:  listening on IPv4 address "0.0.0.0", port 5432
2019-06-12 08:35:49.751 GMT [1] LOG:  listening on IPv6 address "::", port 5432
2019-06-12 08:35:49.769 GMT [1] LOG:  listening on Unix socket "/tmp/.s.PGSQL.5432"
2019-06-12 08:35:49.803 GMT [221] LOG:  database system was shut down at 2019-06-12 08:35:48 GMT
2019-06-12 08:35:49.814 GMT [1] LOG:  database system is ready to accept connections
2019-06-12 08:35:56.590 GMT [240] FATAL:  database "hmcts" does not exist
2019-06-12 08:35:58.031 GMT [241] FATAL:  database "hmcts" does not exist
```

https://github.com/bitnami/bitnami-docker-postgresql/blob/master/README.md#creating-a-database-on-first-run

Tested fix passing POSTGRESQL_DATABASE via extraEnv value in Helm chart.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
