### PR TITLE
Changing default memory, cpu requests and limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,14 @@ The following table lists the configurable parameters of the Java chart and thei
 | `image`                    | Full image url | `hmctssandbox.azurecr.io/hmcts/spring-boot-template`<br>(but overridden by pipeline) |
 | `environment`              |  A map containing all environment values you wish to set. <br> **Note**: environment variables (the key in KEY: value) must be uppercase and only contain letters,  "_", or numbers and value can be templated | `nil`|
 | `configmap`                | A config map, can be used for environment specific config.| `nil`|
-| `memoryRequests`           | Requests for memory | `512Mi`|
-| `cpuRequests`              | Requests for cpu | `25m`|
-| `memoryLimits`             | Memory limits| `1024Mi`|
-| `cpuLimits`                | CPU limits | `2500m`|
+| `devmemoryRequests`           | Requests for memory, set when `global.devMode` is set to true | `512Mi`|
+| `devcpuRequests`              | Requests for cpu, set when `global.devMode` is set to true | `25m`|
+| `devmemoryLimits`             | Memory limits, set when `global.devMode` is set to true| `1024Mi`|
+| `devcpuLimits`                | CPU limits, set when `global.devMode` is set to true | `2500m`|
+| `memoryRequests`           | Requests for memory, set when `global.devMode` is set to false | `512Mi`|
+| `cpuRequests`              | Requests for cpu, set when `global.devMode` is set to false | `250m`|
+| `memoryLimits`             | Memory limits, set when `global.devMode` is set to false| `2048Mi`|
+| `cpuLimits`                | CPU limits, set when `global.devMode` is set to false | `1000m`|
 | `ingressHost`              | Host for ingress controller to map the container to. It supports templating, Example : {{.Release.Name}}.service.core-compute-preview.internal   | `nil`|
 | `registerAdditionalDns.enabled`            | If you want to use this chart as a secondary dependency - e.g. providing a frontend to a backend, and the backend is using primary ingressHost DNS mapping. Note: you will also need to define: `ingressIP: ${INGRESS_IP}` and `consulIP: ${CONSUL_LB_IP}` - this will be populated by pipeline                           | `false`      
 | `registerAdditionalDns.primaryIngressHost`            | The hostname for primary chart. It supports templating, Example : {{.Release.Name}}.service.core-compute-preview.internal                           | `nil`      

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 2.6.0
+version: 2.7.0
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -83,6 +83,15 @@ spec:
           {{- end }}
         {{- end }}
 
+        {{if .Values.global.devMode -}}
+        resources:
+          requests:
+            memory: {{ .Values.devmemoryRequests }}
+            cpu: {{ .Values.devcpuRequests }}
+          limits:
+            memory: {{ .Values.devmemoryLimits }}
+            cpu: {{ .Values.devcpuLimits }}
+        {{- else -}}
         resources:
           requests:
             memory: {{ .Values.memoryRequests }}
@@ -90,6 +99,8 @@ spec:
           limits:
             memory: {{ .Values.memoryLimits }}
             cpu: {{ .Values.cpuLimits }}
+        {{- end }}
+
         ports:
         - containerPort: {{ .Values.applicationPort }}
           name: http

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -4,9 +4,13 @@ replicas: 1
 registerAdditionalDns:
   enabled: false
 memoryRequests: '512Mi'
-cpuRequests: '25m'
-memoryLimits: '1024Mi'
-cpuLimits: '2500m'
+cpuRequests: '250m'
+memoryLimits: '2048Mi'
+cpuLimits: '1000m'
+devmemoryRequests: '512Mi'
+devcpuRequests: '25m'
+devmemoryLimits: '1024Mi'
+devcpuLimits: '2500m'
 readinessPath: '/health'
 readinessDelay: 30
 readinessTimeout: 3
@@ -37,6 +41,7 @@ postgresql:
   postgresqlDatabase: javadatabase
 global:
   enableKeyVaults: false
+  devMode: false
 prometheus:
   enabled: false
   path: /prometheus


### PR DESCRIPTION
Currently, we are overriding them in each manifest which is a pain . Will do a Jenkins Library PR to set global.devMode = true for PRs and staging to use limited resources.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
