### PR TITLE
make appinsights key default added only in devmode(prs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ The following table lists the configurable parameters of the Java chart and thei
 | `livenessFailureThreshold` | Liveness failure threshold | `3` |
 | `secrets`                  | Mappings of environment variables to service objects or pre-configured kubernetes secrets |  nil |
 | `keyVaults`                | Mappings of keyvaults to be mounted as flexvolumes (see Example Configuration) |  nil |
-| `applicationInsightsInstrumentKey` | Instrumentation Key for App Insights , It is mapped to `AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY` as environment variable | `00000000-0000-0000-0000-000000000000`
+| `applicationInsightsInstrumentKey` | Instrumentation Key for App Insights , It is mapped to `AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY` as environment variable when global.devMode is not set to true | `nil`
+| `devApplicationInsightsInstrumentKey` | Instrumentation Key for App Insights , It is mapped to `AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY` as environment variable when global.devMode is set to true | `00000000-0000-0000-0000-000000000000`
 | `pdb.enabled` | To enable PodDisruptionBudget on the pods for handling disruptions | `true` |
 | `pdb.maxUnavailable` |  To configure the number of pods from the set that can be unavailable after the eviction. It can be either an absolute number or a percentage. pdb.minAvailable takes precedence over this if not nil | `50%` means evictions are allowed as long as no more than 50% of the desired replicas are unhealthy. It will allow disruption if you have only 1 replica.|
 | `pdb.minAvailable` |  To configure the number of pods from that set that must still be available after the eviction, even in the absence of the evicted pod. minAvailable can be either an absolute number or a percentage. This takes precedence over pdb.maxUnavailable if not nil. | `nil`|

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: A Helm chart for HMCTS Java Microservices
 name: java
-version: 2.8.0
+version: 2.9.0
 icon: https://github.com/hmcts/chart-java/raw/master/images/icons8-java-50.png
 keywords:
 - java

--- a/java/templates/deployment.yaml
+++ b/java/templates/deployment.yaml
@@ -61,8 +61,13 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
         env:
+        {{- if .Values.global.devMode -}}
+        - name: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
+          value: {{ .Values.devApplicationInsightsInstrumentKey | quote }}
+        {{- else if .Values.applicationInsightsInstrumentKey -}}
         - name: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
           value: {{ .Values.applicationInsightsInstrumentKey | quote }}
+        {{- end -}}
           {{- (include "java.secrets" .) | indent 8 }}
           {{- (include "java.environment" .) | indent 8 }}
 

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -20,7 +20,7 @@ livenessDelay: 30
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
-applicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
+devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
 useInterpodAntiAffinity: false
 pdb:
   enabled: true


### PR DESCRIPTION
With the current implementation, default values takes precedence over appinsights key set from keyvault flexvolumes


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
