### PR TITLE
DTSPO-2201 Add startup probes and upgrade chart-library to 0.6.3

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -15,10 +15,14 @@ resources:
     name: hmcts/cnp-azuredevops-libraries
     endpoint: 'hmcts'
 
+variables:
+  - name: agentPool
+    value: ubuntu-latest
+
 jobs:
 - job: Validate
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: ${{ variables.agentPool }}
   steps:
   - template: steps/charts/validate.yaml@cnp-library
     parameters:
@@ -36,7 +40,7 @@ jobs:
       )
   dependsOn: Validate
   pool:
-    vmImage: 'Ubuntu 16.04'
+    vmImage: ${{ variables.agentPool }}
   steps:
   - template: steps/charts/release.yaml@cnp-library
     parameters:

--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
 
 dependencies:
   - name: library
-    version: 0.6.1
+    version: 0.6.3
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 8.9.8

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -17,14 +17,14 @@ readinessDelay: 30
 readinessTimeout: 3
 readinessPeriod: 15
 livenessPath: '/health/liveness'
-livenessDelay: 30
+livenessDelay: 0
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
 startupPath: '/health/liveness'
-startupDelay: 30
+startupDelay: 20
 startupTimeout: 3
-startupPeriod: 15
+startupPeriod: 10
 startupFailureThreshold: 3
 saEnabled: true
 devApplicationInsightsInstrumentKeyName: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -21,6 +21,11 @@ livenessDelay: 30
 livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
+startupPath: '/health/liveness'
+startupDelay: 30
+startupTimeout: 3
+startupPeriod: 15
+startupFailureThreshold: 3
 saEnabled: true
 devApplicationInsightsInstrumentKeyName: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY
 devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -13,7 +13,7 @@ devcpuRequests: '250m'
 devmemoryLimits: '1024Mi'
 devcpuLimits: '2500m'
 readinessPath: '/health/readiness'
-readinessDelay: 30
+readinessDelay: 0
 readinessTimeout: 3
 readinessPeriod: 15
 livenessPath: '/health/liveness'

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -22,7 +22,7 @@ livenessTimeout: 3
 livenessPeriod: 15
 livenessFailureThreshold: 3
 startupPath: '/health/liveness'
-startupDelay: 20
+startupDelay: 5
 startupTimeout: 3
 startupPeriod: 10
 startupFailureThreshold: 3


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-2201


### Change description ###
Added startup probe values - introduced in chart-library 0.6.3
Upgrade chart-library version to 0.6.3
Updated pipeline pool agent to use ubuntu-latest


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```
