### PR TITLE
Bump chart-library version

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
 
 dependencies:
   - name: library
-    version: 1.0.7
+    version: 1.0.8
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 11.6.14

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -31,6 +31,7 @@ devApplicationInsightsInstrumentKeyName: AZURE_APPLICATIONINSIGHTS_INSTRUMENTATI
 devApplicationInsightsInstrumentKey: '00000000-0000-0000-0000-000000000000'
 useInterpodAntiAffinity: true
 ingressClass: traefik
+disableTraefikTls: true
 # WARNING: ingressSessionAffinity is a temporary option.
 # This is subject to removal without notice. Do NOT use for any reason!
 ingressSessionAffinity:


### PR DESCRIPTION
Update to point to https://github.com/hmcts/chart-library/releases/tag/1.0.8 which includes the new disabletraefik global logic, will be added as a new release and then tested with plum.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
