### PR TITLE
Update Chart.yaml

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
 
 dependencies:
   - name: library
-    version: 1.0.8
+    version: 1.0.9-alpha
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 11.6.14


### PR DESCRIPTION
Bump chart-library version, similar done in node https://github.com/hmcts/chart-nodejs/releases/tag/v2.4.5-beta using this release https://github.com/hmcts/chart-library/releases/tag/1.0.9-alpha of chart-library.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
