### PR TITLE
Bump chart-library version

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
 
 dependencies:
   - name: library
-    version: 2.0.5
+    version: 2.0.6
     repository: https://hmctspublic.azurecr.io/helm/v1/repo/
   - name: postgresql
     version: 12.1.14


### PR DESCRIPTION
Withdrawn story functionality has been removed from chart-library


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
