### PR TITLE
Remove default image in chart

### DIFF
--- a/java/values.yaml
+++ b/java/values.yaml
@@ -1,5 +1,4 @@
 applicationPort: 4550
-image: hmctspublic.azurecr.io/spring-boot/template
 imagePullPolicy: IfNotPresent
 replicas: 1
 registerAdditionalDns:


### PR DESCRIPTION
Noticed in https://github.com/hmcts/am-role-assignment-batch-service/blob/master/charts/am-role-assignment-batch-service/Chart.yaml

It was pulling a spring boot template image (a very old one 2020 which does not have cgroup v2 support)