### PR TITLE
Update to pull image from ACR cache

### DIFF
--- a/java/values.yaml
+++ b/java/values.yaml
@@ -48,6 +48,8 @@ pdb:
 
 postgresql:
   image:
+    registry: hmctspublic.azurecr.io
+    repository: imported/bitnami/postgres
     tag: '11.16.0'
   ## Whether to deploy the Postgres Chart or not
   enabled: false

--- a/java/values.yaml
+++ b/java/values.yaml
@@ -49,7 +49,7 @@ pdb:
 postgresql:
   image:
     registry: hmctspublic.azurecr.io
-    repository: imported/bitnami/postgres
+    repository: imported/bitnami/postgresql
     tag: '11.16.0'
   ## Whether to deploy the Postgres Chart or not
   enabled: false


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14808

Updating to point to our ACR repository with a cache rule for Postgresql image



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
