### PR TITLE
Updating chart library to use the OCI endpoint

### DIFF
--- a/java/Chart.yaml
+++ b/java/Chart.yaml
@@ -16,8 +16,8 @@ keywords:
 
 dependencies:
   - name: library
-    version: 2.2.1
-    repository: https://hmctspublic.azurecr.io/helm/v1/repo/
+    version: 2.2.2
+    repository: oci://hmctspublic.azurecr.io/helm
   - name: postgresql
     version: 14.0.1
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-23130

### Change description
Updating Chart library reference to point at the new OCI endpoint as part of the upgrade work for DTSPO-23130. 
All base charts will need an update as part of this work.

The new release off the back of this PR will also move chart-java to the OCI endpoint.

### Testing done
Tested using this [PR](https://github.com/hmcts/cnp-plum-recipes-service/pull/1118) on the cnp-plum-recipe-service repo and pipeline. 
Build successfully went green with the changes in this PR using the [pre-release](https://github.com/hmcts/chart-java/releases/tag/v5.3.0-beta) for chart java V5


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
